### PR TITLE
Refactor duplicate todos/events/deadlines check

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDeadlineCommand.java
@@ -12,7 +12,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.project.Project;
-import seedu.address.model.task.CompletableDeadline;
+import seedu.address.model.project.exceptions.DuplicateDeadlineException;
 import seedu.address.model.task.deadline.Deadline;
 
 /**
@@ -58,13 +58,12 @@ public class AddDeadlineCommand extends Command {
         Project projectToEdit = lastShownList.get(index.getZeroBased());
         assert projectToEdit != null;
 
-        for (CompletableDeadline deadline: projectToEdit.getDeadlines().getDeadlines()) {
-            if (this.toAdd.equals(deadline)) {
-                throw new CommandException(Messages.MESSAGE_DUPLICATE_DEADLINE);
-            }
+        try {
+            projectToEdit.addDeadline(toAdd);
+        } catch (DuplicateDeadlineException e) {
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_DEADLINE);
         }
 
-        projectToEdit.addDeadline(toAdd);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);
         return new CommandResult(String.format(Messages.MESSAGE_ADD_DEADLINE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.project.Project;
+import seedu.address.model.project.exceptions.DuplicateEventException;
 import seedu.address.model.task.repeatable.Event;
 
 /**
@@ -59,13 +60,12 @@ public class AddEventCommand extends Command {
         Project projectToEdit = lastShownList.get(index.getZeroBased());
         assert projectToEdit != null;
 
-        for (Event event: projectToEdit.getEvents().getEvents()) {
-            if (this.toAdd.equals(event)) {
-                throw new CommandException(Messages.MESSAGE_DUPLICATE_EVENT);
-            }
+        try {
+            projectToEdit.addEvent(toAdd);
+        } catch (DuplicateEventException e) {
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_EVENT);
         }
 
-        projectToEdit.addEvent(toAdd);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);
         return new CommandResult(String.format(Messages.MESSAGE_ADD_EVENT_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/AddTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTodoCommand.java
@@ -10,7 +10,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.project.Project;
-import seedu.address.model.task.CompletableTodo;
+import seedu.address.model.project.exceptions.DuplicateTodoException;
 import seedu.address.model.task.todo.Todo;
 
 public class AddTodoCommand extends Command {
@@ -49,13 +49,12 @@ public class AddTodoCommand extends Command {
         Project projectToEdit = lastShownList.get(index.getZeroBased());
         assert projectToEdit != null;
 
-        for (CompletableTodo todo: projectToEdit.getTodos().getTodos()) {
-            if (this.toAdd.equals(todo)) {
-                throw new CommandException(Messages.MESSAGE_DUPLICATE_TODO);
-            }
+        try {
+            projectToEdit.addTodo(toAdd);
+        } catch (DuplicateTodoException e) {
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_TODO);
         }
 
-        projectToEdit.addTodo(toAdd);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);
         return new CommandResult(String.format(Messages.MESSAGE_ADD_TODO_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/model/project/DeadlineList.java
+++ b/src/main/java/seedu/address/model/project/DeadlineList.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import seedu.address.model.project.exceptions.DuplicateDeadlineException;
 import seedu.address.model.task.CompletableDeadline;
 import seedu.address.model.task.deadline.Deadline;
 
@@ -37,12 +38,18 @@ public class DeadlineList {
     }
 
     /**
-     * Adds a deadline to this {@code DeadlineList}.
+     * Adds a deadline to this {@code DeadlineList}.The {@code Deadline} must not already exist in
+     * the {@code DeadlineList}.
      *
      * @param deadline {@code Deadline} to add.
      */
     public void addDeadline(Deadline deadline) {
         requireNonNull(deadline);
+
+        if (hasDeadline(deadline)) {
+            throw new DuplicateDeadlineException();
+        }
+
         this.deadlines.add(deadline);
     }
 
@@ -107,6 +114,21 @@ public class DeadlineList {
      */
     public Stream<CompletableDeadline> stream() {
         return deadlines.stream();
+    }
+
+    /**
+     * Checks if the {@code DeadlineList} already contains the specified {@code deadlineToCheck}.
+     *
+     * @param deadlineToCheck The deadline that is to be checked.
+     * @return true if this project contains the specified deadline, false otherwise.
+     */
+    public boolean hasDeadline(CompletableDeadline deadlineToCheck) {
+        for (CompletableDeadline deadline: deadlines) {
+            if (deadlineToCheck.equals(deadline)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/EventList.java
+++ b/src/main/java/seedu/address/model/project/EventList.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import seedu.address.model.project.exceptions.DuplicateEventException;
 import seedu.address.model.task.repeatable.Event;
 
 /**
@@ -36,12 +37,17 @@ public class EventList {
     }
 
     /**
-     * Adds an event to this {@code EventList}.
+     * Adds an event to this {@code EventList}. The {@code Event} must not already exist in the {@code EventList}.
      *
      * @param event {@code Event} to add.
      */
     public void addEvent(Event event) {
         requireNonNull(event);
+
+        if (hasEvent(event)) {
+            throw new DuplicateEventException();
+        }
+
         this.events.add(event);
     }
 
@@ -102,6 +108,21 @@ public class EventList {
         requireNonNull(dateOfEvent);
         Predicate<Event> predicate = event -> event.getAt().isEqual(dateOfEvent);
         return events.filtered(predicate);
+    }
+
+    /**
+     * Checks if the {@code EventList} already contains the specified {@code event}.
+     *
+     * @param eventToCheck The event that is to be checked.
+     * @return true if this project contains the specified event, false otherwise.
+     */
+    public boolean hasEvent(Event eventToCheck) {
+        for (Event event: events) {
+            if (eventToCheck.equals(event)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/EventList.java
+++ b/src/main/java/seedu/address/model/project/EventList.java
@@ -111,7 +111,7 @@ public class EventList {
     }
 
     /**
-     * Checks if the {@code EventList} already contains the specified {@code event}.
+     * Checks if the {@code EventList} already contains the specified {@code eventToCheck}.
      *
      * @param eventToCheck The event that is to be checked.
      * @return true if this project contains the specified event, false otherwise.

--- a/src/main/java/seedu/address/model/project/TodoList.java
+++ b/src/main/java/seedu/address/model/project/TodoList.java
@@ -7,8 +7,8 @@ import java.util.stream.Stream;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.project.exceptions.DuplicateTodoException;
 import seedu.address.model.task.CompletableTodo;
-import seedu.address.model.task.todo.Todo;
 
 /**
  * Represents a list of Todos.
@@ -34,12 +34,17 @@ public class TodoList {
     }
 
     /**
-     * Adds a todo to this {@code TodoList}.
+     * Adds a todo to this {@code TodoList}. The {@code CompletableTodo} must not already exist in the {@code TodoList}.
      *
      * @param todo {@code Todo} to add.
      */
-    public void addTodo(Todo todo) {
+    public void addTodo(CompletableTodo todo) {
         requireNonNull(todo);
+
+        if (hasTodo(todo)) {
+            throw new DuplicateTodoException();
+        }
+
         this.todos.add(todo);
     }
 
@@ -92,6 +97,21 @@ public class TodoList {
      */
     public Stream<CompletableTodo> stream() {
         return this.todos.stream();
+    }
+
+    /**
+     * Checks if the {@code TodoList} already contains the specified {@code todoToCheck}.
+     *
+     * @param todoToCheck The todo that is to be checked.
+     * @return true if this project contains the specified todo, false otherwise.
+     */
+    public boolean hasTodo(CompletableTodo todoToCheck) {
+        for (CompletableTodo todo: todos) {
+            if (todoToCheck.equals(todo)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/exceptions/DuplicateDeadlineException.java
+++ b/src/main/java/seedu/address/model/project/exceptions/DuplicateDeadlineException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.project.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Deadlines.
+ */
+public class DuplicateDeadlineException extends RuntimeException {
+    public DuplicateDeadlineException() {
+        super("Operation would result in duplicate deadlines.");
+    }
+}

--- a/src/main/java/seedu/address/model/project/exceptions/DuplicateEventException.java
+++ b/src/main/java/seedu/address/model/project/exceptions/DuplicateEventException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.project.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Events.
+ */
+public class DuplicateEventException extends RuntimeException {
+    public DuplicateEventException() {
+        super("Operation would result in duplicate events.");
+    }
+}

--- a/src/main/java/seedu/address/model/project/exceptions/DuplicateTodoException.java
+++ b/src/main/java/seedu/address/model/project/exceptions/DuplicateTodoException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.project.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Todos.
+ */
+public class DuplicateTodoException extends RuntimeException {
+    public DuplicateTodoException() {
+        super("Operation would result in duplicate todos.");
+    }
+}


### PR DESCRIPTION
Move check for duplicates from `AddXXXCommand` to `XXXList`.

1) This is a more defensive way to prevent `XXXList` from having duplicates. It does not have to rely on other classes to check for duplicates anymore.
2) This better follows demeter's law. Previously, there was a call to `projectToEdit.getXXX().getXXX()` in `AddXXXCommand`, now the command simply adds the project and the `XXXList` will throw an exception if there are duplicates.
3) We can reuse the `hasXXX()` method in `XXXList` for `editXXX` command.

XXX refers to one of events, todos, deadlines.