### PR TITLE
Undo redo changes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -555,11 +555,25 @@ CoLAB's data is saved as a JSON file `[JAR file location]/data/colab.json`. Adva
 If your changes to the data file makes its format invalid, CoLAB will discard all data and start with an empty data file at the next run.
 </div>
 
-### **4.5 Coming soon**
+#### Undoing previous command : `undo`
 
-#### Undo/Redo `[coming soon]`
+Restores colab to the state before the previous undoable command was executed.
 
-_Details coming soon ..._
+Format: `undo'
+
+* Undoable commands are start with `add`, `update` or `delete`.
+* All other commands are not undoable.
+
+Example:
+
+* `deleteP 1` Deletes the first project in the list.
+* `undo` Reverses the `deleteP 1` command. 
+
+#### Redoing previous command : `redo`
+
+Reverses the most recent undo command.
+
+Format: `redo'
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/logic/commands/FindContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindContactCommand.java
@@ -32,7 +32,7 @@ public class FindContactCommand extends Command {
         model.updateFilteredContactList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW, model.getFilteredContactList().size()),
-                new ShowContactsUiCommand());
+                new ShowContactsUiCommand()).setIgnoreHistory(true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -17,6 +17,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, new ShowHelpUiCommand());
+        return new CommandResult(SHOWING_HELP_MESSAGE, new ShowHelpUiCommand()).setIgnoreHistory(true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewContactsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactsCommand.java
@@ -20,6 +20,6 @@ public class ViewContactsCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
-        return new CommandResult(MESSAGE_SUCCESS, new ShowContactsUiCommand());
+        return new CommandResult(MESSAGE_SUCCESS, new ShowContactsUiCommand()).setIgnoreHistory(true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewOverviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewOverviewCommand.java
@@ -19,6 +19,6 @@ public class ViewOverviewCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(MESSAGE_SUCCESS, new ShowOverviewTabUiCommand());
+        return new CommandResult(MESSAGE_SUCCESS, new ShowOverviewTabUiCommand()).setIgnoreHistory(true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewProjectCommand.java
@@ -41,6 +41,7 @@ public class ViewProjectCommand extends Command {
         }
 
         return new CommandResult(String.format(MESSAGE_SUCCESS,
-                lastShownList.get(index.getZeroBased()).getProjectName()), new ViewProjectAndOverviewUiCommand(index));
+                lastShownList.get(index.getZeroBased()).getProjectName()), new ViewProjectAndOverviewUiCommand(index))
+                    .setIgnoreHistory(true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewTodayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTodayCommand.java
@@ -19,6 +19,6 @@ public class ViewTodayCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(MESSAGE_SUCCESS, new ShowTodayUiCommand());
+        return new CommandResult(MESSAGE_SUCCESS, new ShowTodayUiCommand()).setIgnoreHistory(true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewTodosCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTodosCommand.java
@@ -19,6 +19,6 @@ public class ViewTodosCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(MESSAGE_SUCCESS, new ShowTodosTabUiCommand());
+        return new CommandResult(MESSAGE_SUCCESS, new ShowTodosTabUiCommand()).setIgnoreHistory(true);
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -276,6 +276,7 @@
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
     -fx-text-fill: white;
+    -fx-text-alignment: justify;
 }
 
 #contactListView, #projectListView {


### PR DESCRIPTION
closes #234 

undo redo now only works for redouble commands, add/delete/update. this is to avoid inconsistencies when pressing buttons  in the ui.

updated ug with details on undo/redo

text in command result  box now  justified